### PR TITLE
Add the Articles of Incorporation to our published policies

### DIFF
--- a/abuse-policy.md
+++ b/abuse-policy.md
@@ -17,6 +17,6 @@ availability for other cooperative members, the IP address will be immediately
 blocked and the member will be notified of the abuse and the block.
 
 Once the abuse is resolved the member's IP address may be unblocked. IO 
-Cooperative will [terminate membership](https://iocoop.org/policies/bylaws#section-503-expulsion)
+Cooperative will [terminate membership](../bylaws#section-503-expulsion)
 of any member who repeatedly allows abuse to originate from their IP address or
 if the IO Cooperative board deems the abuse to be intentional.

--- a/articles-of-incorporation.md
+++ b/articles-of-incorporation.md
@@ -1,0 +1,35 @@
+Title: IO Cooperative, Inc. Articles of Incorporation
+
+**Article 1**. The name of this Corporation is IO Cooperative, Inc.
+
+**Article 2**. This Corporation is a cooperative corporation organized under the California Consumer Cooperative Law. The purpose of this Corporation is to engage in any lawful act or activity for which a corporation may be organized under such law.
+
+**Article 3**. The name and address in the State of California of this Corporation's initial agent for service of process is **Ben Kochie, [address redacted for privacy]**.
+
+**Article 4**. The voting rights of each member of the Corporation are equal, and each member is entitled to one vote. The proprietary interests of each member in the Corporation are equal, and the rules for obtaining and transferring shares shall be described in the Bylaws of the Corporation.
+
+**Article 5**. The names and post office addresses of incorporators who shall serve until the first annual meeting are:
+
+<br />
+Christian Haumesser
+
+[address redacted for privacy]
+
+<br />
+Ben Kochie
+
+[address redacted for privacy]
+
+<br />
+IN WITNESS WHEREOF, the undersigned, being the Incorporators of this Corporation, have executed these Articles of Incorporation on February 12, 2012.
+
+<br />
+[signature]
+
+Ben Kochie
+
+<br />
+[signature]
+
+Christian Haumesser
+

--- a/articles-of-incorporation.md
+++ b/articles-of-incorporation.md
@@ -4,7 +4,7 @@ Title: IO Cooperative, Inc. Articles of Incorporation
 
 **Article 2**. This Corporation is a cooperative corporation organized under the California Consumer Cooperative Law. The purpose of this Corporation is to engage in any lawful act or activity for which a corporation may be organized under such law.
 
-**Article 3**. The name and address in the State of California of this Corporation's initial agent for service of process is **Ben Kochie, [address redacted for privacy]**.
+**Article 3**. The name and address in the State of California of this Corporation's initial agent for service of process is **Ben Kochie, [address]**.
 
 **Article 4**. The voting rights of each member of the Corporation are equal, and each member is entitled to one vote. The proprietary interests of each member in the Corporation are equal, and the rules for obtaining and transferring shares shall be described in the Bylaws of the Corporation.
 
@@ -13,12 +13,12 @@ Title: IO Cooperative, Inc. Articles of Incorporation
 <br />
 Christian Haumesser
 
-[address redacted for privacy]
+[address]
 
 <br />
 Ben Kochie
 
-[address redacted for privacy]
+[address]
 
 <br />
 IN WITNESS WHEREOF, the undersigned, being the Incorporators of this Corporation, have executed these Articles of Incorporation on February 12, 2012.

--- a/bylaws.md
+++ b/bylaws.md
@@ -90,7 +90,7 @@ No member may transfer his or her membership or any right arising therefrom.
 
 ### Section 4.07. Bylaws and Disclosures.
 
-Each prospective member, upon application for membership, must receive a copy of the Articles of Incorporation, Bylaws, and other relevant disclosures required by Coop Law Section 12401(b).
+Each prospective member, upon application for membership, must receive a copy of the [Articles of Incorporation](../articles-of-incorporation), Bylaws, and other relevant disclosures required by Coop Law Section 12401(b).
 
 ### Section 4.08. Membership Issuance.
 
@@ -98,7 +98,7 @@ Memberships may be issued for money paid in an amount and on terms determined fr
 
 ### Section 4.09. Membership Ownership.
 
-Membership ownership entitles a member to only one vote in the affairs of the Corporation, and to all the rights of membership as described by statute, the Articles of Incorporation, and these Bylaws. The Corporation will not pay dividends on memberships.
+Membership ownership entitles a member to only one vote in the affairs of the Corporation, and to all the rights of membership as described by statute, the [Articles of Incorporation](../articles-of-incorporation), and these Bylaws. The Corporation will not pay dividends on memberships.
 
 ### Section 4.10. Membership Receipt and Disclosures.
 
@@ -298,7 +298,7 @@ A majority of the authorized number of Directors constitutes a quorum for the tr
 
 ### Section 7.13. Acts of Board at Meetings.
 
-Unless provided otherwise in the Articles of Incorporation, these Bylaws, or by law, every act or decision done or made by a majority of the Directors present at a duly held meeting at which a quorum is present is the act of the Board. A meeting at which a quorum is initially present may continue to transact business notwithstanding the withdrawal of Directors, if any action taken is approved by at least a majority of the required quorum for the meeting or a greater number required by the Articles, these Bylaws, or by law.
+Unless provided otherwise in the [Articles of Incorporation](../articles-of-incorporation), these Bylaws, or by law, every act or decision done or made by a majority of the Directors present at a duly held meeting at which a quorum is present is the act of the Board. A meeting at which a quorum is initially present may continue to transact business notwithstanding the withdrawal of Directors, if any action taken is approved by at least a majority of the required quorum for the meeting or a greater number required by the Articles, these Bylaws, or by law.
 
 ### Section 7.14. Adjournment of Meetings.
 

--- a/index.md
+++ b/index.md
@@ -2,6 +2,7 @@ Title: IO Cooperative Policies
 
 Member documents:
 
+* [IO Cooperative, Inc. Articles of Incorporation](articles-of-incorporation)
 * [Bylaws of IO Cooperative, Inc.](bylaws)
 * [Membership Disclosure Document](membership-disclosure)
 * [Consent and Notice Regarding Electronic Communications](electronic-consent)

--- a/membership-disclosure.md
+++ b/membership-disclosure.md
@@ -8,17 +8,23 @@ IO Cooperative, Inc. is a cooperative corporation organized under the Consumer C
 
 ## 2. Copy of Articles and Bylaws
 
-A copy of the Corporation's Articles of Incorporation and its Bylaws will be furnished without charge to each member or prospective member upon written request. Requests should be sent via electronic mail to [support@iocoop.org][].
+A copy of the Corporation's [Articles of Incorporation][] and its [Bylaws][] will be furnished without charge to each member or prospective member upon written request. Requests should be sent via electronic mail to [support@iocoop.org][].
 
+   [Articles of Incorporation]: ../articles-of-incorporation
+   [Bylaws]: ../bylaws
    [support@iocoop.org]: mailto:support@iocoop.org
 
 ## 3. Assignment or Transfer
 
-No share or membership of this corporation may be assigned or transferred. Any attempted assignment or transfer will be wholly void and will confer no rights on the intended assignee or transferee. (See Bylaw Section 4.11.)
+No share or membership of this corporation may be assigned or transferred. Any attempted assignment or transfer will be wholly void and will confer no rights on the intended assignee or transferee. (See [Bylaw Section 4.11][].)
+
+   [Bylaw Section 4.11]: ../bylaws#section-411-prohibition-on-transfer-of-memberships
 
 ## 4. Termination of Membership
 
-Sections 5.01 through 5.04 of the Bylaws of the Corporation provide as follows:
+Sections [5.01 through 5.04 of the Bylaws of the Corporation][] provide as follows:
+
+   [5.01 through 5.04 of the Bylaws of the Corporation]: ../bylaws#article-v-termination-of-membership
 
 > ### Section 5.01. Voluntary Withdrawal.
 > 
@@ -42,5 +48,10 @@ Sections 5.01 through 5.04 of the Bylaws of the Corporation provide as follows:
 
 ## 5. Member's Proprietary Interest
 
-Membership in the Corporation is not an investment, and members will never be paid dividends on memberships. A member's proprietary interest in the Corporation is limited to the unredeemed total of money received by the Corporation in exchange for all memberships purchased by such member. (See Article 4 of the Articles of Incorporation and Bylaw Sections 4.08, 4.09, 5.04, and 11.03.) A member or former member's proprietary interest does not include amounts transferred to the Corporation pursuant to section 4.13 of the Bylaws (related to "unclaimed" equity interests).
+Membership in the Corporation is not an investment, and members will never be paid dividends on memberships. A member's proprietary interest in the Corporation is limited to the unredeemed total of money received by the Corporation in exchange for all memberships purchased by such member. (See Article 4 of the [Articles of Incorporation][] and Bylaw Sections [4.08][], [4.09][], [5.04][], and [11.03][].) A member or former member's proprietary interest does not include amounts transferred to the Corporation pursuant to [section 4.13 of the Bylaws][] (related to "unclaimed" equity interests).
 
+   [4.08]: ../bylaws#section-408-membership-issuance
+   [4.09]: ../bylaws#section-409-membership-ownership
+   [5.04]: ../bylaws#section-504-settlement-of-membership-interest
+   [11.03]: ../bylaws#section-1103-annual-allocations-and-distributions-of-surplus
+   [section 4.13 of the Bylaws]: ../bylaws#section-413-unclaimed-equity-interests

--- a/privacy-policy.md
+++ b/privacy-policy.md
@@ -6,11 +6,11 @@ We will not sell, trade, or otherwise disclose your information to any entity fo
 
 Except as required by law, we will not knowingly disclose the existence or nature of your business relationship with us except to other members of the cooperative, pursuant to section 10.03 of the [Bylaws][].
 
-   [bylaws]: https://iocoop.org/policies/bylaws/
+   [bylaws]: ../bylaws
 
 We will take all reasonable steps to protect your privacy in a manner consistent with or superior to industry standards. Our [Security Policy][] incorporates privacy goals.
 
-   [security policy]: https://iocoop.org/policies/security-policy/
+   [security policy]: ../security-policy
 
 We will, on occasion, update this privacy policy. When we do, we will take reasonable steps to notify our current and former clients of any such changes. However, it is your responsibility to check this web site for the current privacy policy.
 

--- a/security-policy.md
+++ b/security-policy.md
@@ -10,5 +10,5 @@ Elements of our security policy:
 * We will never require an IO Cooperative member to authenticate over an unencrypted connection
 * Keep systems up to date with security patches
 
-   [privacy policy]: https://iocoop.org/policies/privacy-policy/
+   [privacy policy]: ../privacy-policy
 

--- a/terms-of-service.md
+++ b/terms-of-service.md
@@ -14,9 +14,9 @@ All customers are bound by our terms of service.
 * Services may be terminated without refund for violation of these terms.
 * All activity is monitored for security purposes, though privacy is respected.
 
-   [anti-spam policy]: https://iocoop.org/policies/anti-spam-policy/
-   [abuse policy]: https://iocoop.org/policies/abuse-policy/
-   [billing policy]: https://iocoop.org/policies/billing-policy/
+   [anti-spam policy]: ../anti-spam-policy
+   [abuse policy]: ../abuse-policy
+   [billing policy]: ../billing-policy
 
 We will on occasion update these terms of service. When we do, we will take reasonable steps to notify our current clients of any such changes; however, it is your responsibility to check this page for the current terms of service.
 


### PR DESCRIPTION
While looking up something in our Bylaws, I realized that we reference the Articles of Incorporation but they're not actually available online. This adds the latest version of the Articles and links to them from the Bylaws and Membership Disclosure.

I also fixed up links in the other policies to be relative rather than absolute, so that they'd work correctly when testing out policy changes locally.